### PR TITLE
Double tap camera

### DIFF
--- a/res/layout/quick_camera_controls.xml
+++ b/res/layout/quick_camera_controls.xml
@@ -7,6 +7,30 @@
                 android:gravity="bottom"
                 tools:background="@android:color/darker_gray">
 
+    <ImageView
+        android:id="@+id/front_facing_camera_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_toEndOf="@+id/swap_camera_button"
+        android:layout_toRightOf="@+id/swap_camera_button"
+        android:padding="20dp"
+        android:src="@drawable/ic_face_white_24dp"
+        android:visibility="invisible"
+        tools:visibility="visible" />
+
+    <ImageView
+        android:id="@+id/back_facing_camera_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_toEndOf="@+id/swap_camera_button"
+        android:layout_toRightOf="@+id/swap_camera_button"
+        android:padding="20dp"
+        android:src="@drawable/ic_image_white_24dp"
+        android:visibility="invisible"
+        tools:visibility="visible" />
+
     <ImageButton android:id="@+id/shutter_button"
                  android:layout_width="wrap_content"
                  android:layout_height="wrap_content"
@@ -37,5 +61,4 @@
                  android:padding="20dp"
                  android:visibility="invisible"
                  tools:visibility="visible" />
-
 </RelativeLayout>

--- a/src/org/thoughtcrime/securesms/components/camera/CameraView.java
+++ b/src/org/thoughtcrime/securesms/components/camera/CameraView.java
@@ -59,7 +59,6 @@ public class CameraView extends ViewGroup {
 
   private final CameraSurfaceView   surface;
   private final OnOrientationChange onOrientationChange;
-  private final GestureDetector     doubleTapGestureDetector;
 
 
   private volatile Optional<Camera> camera             = Optional.absent();
@@ -95,18 +94,6 @@ public class CameraView extends ViewGroup {
 
     surface             = new CameraSurfaceView(getContext());
     onOrientationChange = new OnOrientationChange(context.getApplicationContext());
-
-    doubleTapGestureDetector = new GestureDetector(new DoubleTapGestureDetector(this));
-
-    View.OnTouchListener doubleTapListener = new View.OnTouchListener() {
-      @Override
-      public boolean onTouch(View v, MotionEvent event) {
-        doubleTapGestureDetector.onTouchEvent(event);
-        return true;
-      }
-    };
-
-    surface.setOnTouchListener(doubleTapListener);
 
     addView(surface);
   }
@@ -647,25 +634,5 @@ public class CameraView extends ViewGroup {
 
   private enum State {
     PAUSED, RESUMED, ACTIVE
-  }
-
-  private class DoubleTapGestureDetector extends GestureDetector.SimpleOnGestureListener{
-
-    CameraView cameraView;
-
-    public DoubleTapGestureDetector(CameraView cv){
-      this.cameraView = cv;
-    }
-
-    @Override
-    public boolean onDoubleTap(MotionEvent e){
-      cameraView.flipCamera();
-      return true;
-    }
-
-    @Override
-    public boolean onDoubleTapEvent(MotionEvent e){
-      return true;
-    }
   }
 }

--- a/src/org/thoughtcrime/securesms/components/camera/CameraView.java
+++ b/src/org/thoughtcrime/securesms/components/camera/CameraView.java
@@ -33,7 +33,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
 import android.view.OrientationEventListener;
+import android.view.View;
 import android.view.ViewGroup;
 
 import java.io.IOException;
@@ -56,6 +59,8 @@ public class CameraView extends ViewGroup {
 
   private final CameraSurfaceView   surface;
   private final OnOrientationChange onOrientationChange;
+  private final GestureDetector     doubleTapGestureDetector;
+
 
   private volatile Optional<Camera> camera             = Optional.absent();
   private volatile int              cameraId           = CameraInfo.CAMERA_FACING_BACK;
@@ -90,6 +95,19 @@ public class CameraView extends ViewGroup {
 
     surface             = new CameraSurfaceView(getContext());
     onOrientationChange = new OnOrientationChange(context.getApplicationContext());
+
+    doubleTapGestureDetector = new GestureDetector(new DoubleTapGestureDetector(this));
+
+    View.OnTouchListener doubleTapListener = new View.OnTouchListener() {
+      @Override
+      public boolean onTouch(View v, MotionEvent event) {
+        doubleTapGestureDetector.onTouchEvent(event);
+        return true;
+      }
+    };
+
+    surface.setOnTouchListener(doubleTapListener);
+
     addView(surface);
   }
 
@@ -403,6 +421,10 @@ public class CameraView extends ViewGroup {
     return rotation;
   }
 
+  public void onDoubleTap(){
+    flipCamera();
+  }
+
   private class OnOrientationChange extends OrientationEventListener {
     public OnOrientationChange(Context context) {
       super(context);
@@ -625,5 +647,25 @@ public class CameraView extends ViewGroup {
 
   private enum State {
     PAUSED, RESUMED, ACTIVE
+  }
+
+  private class DoubleTapGestureDetector extends GestureDetector.SimpleOnGestureListener{
+
+    CameraView cameraView;
+
+    public DoubleTapGestureDetector(CameraView cv){
+      this.cameraView = cv;
+    }
+
+    @Override
+    public boolean onDoubleTap(MotionEvent e){
+      cameraView.flipCamera();
+      return true;
+    }
+
+    @Override
+    public boolean onDoubleTapEvent(MotionEvent e){
+      return true;
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.hardware.Camera;
+import android.media.Image;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
@@ -21,6 +22,7 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 
 import com.nineoldandroids.animation.ObjectAnimator;
 
@@ -46,6 +48,8 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
   private ImageButton               fullScreenButton;
   private ImageButton               swapCameraButton;
   private ImageButton               shutterButton;
+  private ImageView                 frontCameraIcon;
+  private ImageView                 backCameraIcon;
   private int                       slideOffset;
   private float                     initialMotionX;
   private float                     initialMotionY;
@@ -106,6 +110,9 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
 
   public ImageButton getSwapCameraButton() { return this.swapCameraButton; }
 
+  public ImageView getFrontCameraIcon() { return this.frontCameraIcon; }
+  public ImageView getBackCameraIcon() { return this.backCameraIcon; }
+
   @Override
   public boolean isShowing() {
     return drawerState.isVisible();
@@ -142,10 +149,17 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
     shutterButton    = (ImageButton) controls.findViewById(R.id.shutter_button);
     swapCameraButton = (ImageButton) controls.findViewById(R.id.swap_camera_button);
     fullScreenButton = (ImageButton) controls.findViewById(R.id.fullscreen_button);
+    frontCameraIcon  =               controls.findViewById(R.id.front_facing_camera_icon);
+    backCameraIcon  =               controls.findViewById(R.id.back_facing_camera_icon);
+
     if (cameraView.isMultiCamera()) {
       swapCameraButton.setVisibility(View.VISIBLE);
       swapCameraButton.setImageResource(cameraView.isRearCamera() ? R.drawable.quick_camera_front
                                                                   : R.drawable.quick_camera_rear);
+
+      backCameraIcon.setVisibility(cameraView.isRearCamera() ? View.VISIBLE : View.GONE);
+      frontCameraIcon.setVisibility(cameraView.isRearCamera() ? View.GONE : View.VISIBLE);
+
       swapCameraButton.setOnClickListener(new CameraFlipClickListener());
     }
     shutterButton.setOnClickListener(new ShutterClickListener());
@@ -576,6 +590,8 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
       cameraView.flipCamera();
       swapCameraButton.setImageResource(cameraView.isRearCamera() ? R.drawable.quick_camera_front
                                                                   : R.drawable.quick_camera_rear);
+      backCameraIcon.setVisibility(cameraView.isRearCamera() ? View.VISIBLE : View.GONE);
+      frontCameraIcon.setVisibility(cameraView.isRearCamera() ? View.GONE : View.VISIBLE);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -14,6 +14,7 @@ import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.support.v4.widget.ViewDragHelper;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.GestureDetector;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.Surface;
@@ -51,6 +52,8 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
   private AttachmentDrawerListener  listener;
   private int                       halfExpandedHeight;
   private ObjectAnimator            animator;
+  private GestureDetector           doubleTapGestureDetector;
+
 
   private DrawerState drawerState      = DrawerState.COLLAPSED;
   private Rect        drawChildrenRect = new Rect();
@@ -81,6 +84,18 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
     controls.setVisibility(GONE);
     cameraView.setVisibility(GONE);
     cameraView.addListener(this);
+
+    doubleTapGestureDetector = new GestureDetector(new DoubleTapGestureDetector(cameraView));
+
+    View.OnTouchListener doubleTapListener = new View.OnTouchListener() {
+      @Override
+      public boolean onTouch(View v, MotionEvent event) {
+        doubleTapGestureDetector.onTouchEvent(event);
+        return true;
+      }
+    };
+
+    cameraView.setOnTouchListener(doubleTapListener);
   }
 
   public static boolean isDeviceSupported(Context context) {
@@ -571,6 +586,29 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
       } else {
         setDrawerStateAndUpdate(DrawerState.HALF_EXPANDED);
       }
+    }
+  }
+
+  private class DoubleTapGestureDetector extends GestureDetector.SimpleOnGestureListener{
+
+    CameraView cameraView;
+
+    public DoubleTapGestureDetector(CameraView cv){
+      this.cameraView = cv;
+    }
+
+    @Override
+    public boolean onDoubleTap(MotionEvent e){
+      cameraView.flipCamera();
+      swapCameraButton.setImageResource(cameraView.isRearCamera() ? R.drawable.quick_camera_front
+              : R.drawable.quick_camera_rear);
+
+      return true;
+    }
+
+    @Override
+    public boolean onDoubleTapEvent(MotionEvent e){
+      return true;
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -28,6 +28,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.InputAwareLayout.InputView;
 import org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout;
 import org.thoughtcrime.securesms.components.camera.CameraView.CameraViewListener;
+import org.thoughtcrime.securesms.util.DoubleTapGestureDetector;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
@@ -85,7 +86,7 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
     cameraView.setVisibility(GONE);
     cameraView.addListener(this);
 
-    doubleTapGestureDetector = new GestureDetector(new DoubleTapGestureDetector(cameraView));
+    doubleTapGestureDetector = new GestureDetector(new DoubleTapGestureDetector(this, cameraView));
 
     View.OnTouchListener doubleTapListener = new View.OnTouchListener() {
       @Override
@@ -102,6 +103,8 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
     return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA) &&
            Camera.getNumberOfCameras() > 0;
   }
+
+  public ImageButton getSwapCameraButton() { return this.swapCameraButton; }
 
   @Override
   public boolean isShowing() {
@@ -586,29 +589,6 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
       } else {
         setDrawerStateAndUpdate(DrawerState.HALF_EXPANDED);
       }
-    }
-  }
-
-  private class DoubleTapGestureDetector extends GestureDetector.SimpleOnGestureListener{
-
-    CameraView cameraView;
-
-    public DoubleTapGestureDetector(CameraView cv){
-      this.cameraView = cv;
-    }
-
-    @Override
-    public boolean onDoubleTap(MotionEvent e){
-      cameraView.flipCamera();
-      swapCameraButton.setImageResource(cameraView.isRearCamera() ? R.drawable.quick_camera_front
-              : R.drawable.quick_camera_rear);
-
-      return true;
-    }
-
-    @Override
-    public boolean onDoubleTapEvent(MotionEvent e){
-      return true;
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/util/DoubleTapGestureDetector.java
+++ b/src/org/thoughtcrime/securesms/util/DoubleTapGestureDetector.java
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.util;
 
 import android.view.GestureDetector;
 import android.view.MotionEvent;
+import android.view.View;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.camera.CameraView;
@@ -21,6 +22,8 @@ public class DoubleTapGestureDetector extends GestureDetector.SimpleOnGestureLis
         cameraView.flipCamera();
         quickAttachmentDrawer.getSwapCameraButton().setImageResource(cameraView.isRearCamera() ? R.drawable.quick_camera_front
                 : R.drawable.quick_camera_rear);
+        quickAttachmentDrawer.getBackCameraIcon().setVisibility(cameraView.isRearCamera() ? View.VISIBLE : View.GONE);
+        quickAttachmentDrawer.getFrontCameraIcon().setVisibility(cameraView.isRearCamera() ? View.GONE : View.VISIBLE);
 
         return true;
     }

--- a/src/org/thoughtcrime/securesms/util/DoubleTapGestureDetector.java
+++ b/src/org/thoughtcrime/securesms/util/DoubleTapGestureDetector.java
@@ -1,0 +1,32 @@
+package org.thoughtcrime.securesms.util;
+
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.camera.CameraView;
+import org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer;
+
+public class DoubleTapGestureDetector extends GestureDetector.SimpleOnGestureListener {
+    CameraView cameraView;
+    QuickAttachmentDrawer quickAttachmentDrawer;
+
+    public DoubleTapGestureDetector(QuickAttachmentDrawer qad, CameraView cv){
+        this.cameraView = cv;
+        this.quickAttachmentDrawer = qad;
+    }
+
+    @Override
+    public boolean onDoubleTap(MotionEvent e){
+        cameraView.flipCamera();
+        quickAttachmentDrawer.getSwapCameraButton().setImageResource(cameraView.isRearCamera() ? R.drawable.quick_camera_front
+                : R.drawable.quick_camera_rear);
+
+        return true;
+    }
+
+    @Override
+    public boolean onDoubleTapEvent(MotionEvent e){
+        return true;
+    }
+}

--- a/test/androidTest/java/org/thoughtcrime/securesms/espressoTests/DoubleTapCameraTest.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/espressoTests/DoubleTapCameraTest.java
@@ -1,0 +1,8 @@
+package org.thoughtcrime.securesms.espressoTests;
+
+/**
+ * Created by Claudia on 2018-03-29.
+ */
+
+public class DoubleTapCameraTest {
+}

--- a/test/androidTest/java/org/thoughtcrime/securesms/espressoTests/DoubleTapCameraTest.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/espressoTests/DoubleTapCameraTest.java
@@ -1,8 +1,48 @@
 package org.thoughtcrime.securesms.espressoTests;
 
-/**
- * Created by Claudia on 2018-03-29.
- */
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.thoughtcrime.securesms.ConversationActivity;
+import org.thoughtcrime.securesms.ConversationListActivity;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.ConversationActions;
+import org.thoughtcrime.securesms.util.Expectations;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
 public class DoubleTapCameraTest {
+
+    @Rule
+    public ActivityTestRule<ConversationListActivity> mActivityTestRule = new ActivityTestRule<>(ConversationListActivity.class);
+
+    @Test
+    public void doubleTapCameraTest(){
+        // Open a new conversation.
+        ConversationActions.createNewConversation("5149714708");
+        ConversationActions.enableSignalForSMS();
+
+        //Open the quick attachment camera
+        ConversationActions.openQuickAttachmentDrawer();
+        Expectations.checkIsDisplayed(R.id.back_facing_camera_icon); //assuming the camera starts as back facing
+        Expectations.checkIsNotDisplayed(R.id.front_facing_camera_icon);
+
+        //put the camera into full screen
+        //this needs to be done or else the double click won't work (error: 90% of the view needs to be visible
+        // to the user) and the test will fail
+        Expectations.checkIsDisplayed(R.id.fullscreen_button);
+        ConversationActions.clickOnViewWithId(R.id.fullscreen_button);
+
+        //flip camera and check that it flipped
+        ConversationActions.doubleClickViewWithId(R.id.quick_camera);
+        Expectations.checkIsNotDisplayed(R.id.back_facing_camera_icon);
+        Expectations.checkIsDisplayed(R.id.front_facing_camera_icon);
+
+        //put the camera back to back facing so we can rerun the test
+        ConversationActions.doubleClickViewWithId(R.id.quick_camera);
+    }
 }

--- a/test/androidTest/java/org/thoughtcrime/securesms/util/ConversationActions.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/util/ConversationActions.java
@@ -20,6 +20,7 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.doubleClick;
 import static android.support.test.espresso.action.ViewActions.longClick;
 import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
@@ -102,6 +103,22 @@ public class ConversationActions {
 
         try {
             UiObject button = uiDevice.findObject(new UiSelector().resourceId("org.thoughtcrime.securesms:id/send_button"));
+            button.waitForExists(3000);
+            if (button.isEnabled()) {
+                button.click();
+            }
+        } catch (Exception e) {
+            System.out.println("Already enabled");
+        }
+    }
+
+
+    public static void openQuickAttachmentDrawer(){
+        // Initialize UiDevice instance
+        UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        try {
+            UiObject button = uiDevice.findObject(new UiSelector().resourceId("org.thoughtcrime.securesms:id/quick_camera_toggle"));
             button.waitForExists(3000);
             if (button.isEnabled()) {
                 button.click();
@@ -199,6 +216,17 @@ public class ConversationActions {
         ViewInteraction recyclerView = onView(
                 allOf(withId(android.R.id.list)));
         recyclerView.perform(actionOnItemAtPosition(messageIndex, longClick()));
+    }
+
+    public static void doubleClickViewWithId(int id){
+        ViewInteraction view = onView(withId(id));
+        view.perform(doubleClick());
+    }
+
+    public static void clickOnViewWithId(int id){
+        ViewInteraction view = onView(withId(id));
+        view.perform(click());
+
     }
 
     public static void pressMessageAt(int messageIndex) {

--- a/test/androidTest/java/org/thoughtcrime/securesms/util/Expectations.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/util/Expectations.java
@@ -8,8 +8,10 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withResourceName;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.not;
@@ -17,6 +19,10 @@ import static org.hamcrest.Matchers.not;
 public class Expectations {
     public static void checkIsDisplayed(int id) {
         onView(withId(id)).check(matches(isDisplayed()));
+    }
+
+    public static void checkIsDisplayedWithRearCameraDrawable(int id){
+        onView(allOf(withId(id), withResourceName("R.drawable.quick_camera_rear"))).check(matches(isDisplayed()));
     }
 
     public static void checkIsDisplayed(int id, String message) {
@@ -29,6 +35,10 @@ public class Expectations {
 
     public static void checkIsNotDisplayed(int id, String message) {
         onView(allOf(withId(id), withText(message))).check(matches(not(isDisplayed())));
+    }
+
+    public static void checkIsNotDisplayed(int id) {
+        onView(withId(id)).check(matches(not(isDisplayed())));
     }
 
     public static void checkDoesNotExist(int id) {

--- a/test/androidTest/java/org/thoughtcrime/securesms/util/Expectations.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/util/Expectations.java
@@ -21,10 +21,6 @@ public class Expectations {
         onView(withId(id)).check(matches(isDisplayed()));
     }
 
-    public static void checkIsDisplayedWithRearCameraDrawable(int id){
-        onView(allOf(withId(id), withResourceName("R.drawable.quick_camera_rear"))).check(matches(isDisplayed()));
-    }
-
     public static void checkIsDisplayed(int id, String message) {
         onView(allOf(withId(id), withText(message))).check(matches(isDisplayed()));
     }

--- a/test/unitTest/java/org/thoughtcrime/securesms/components/camera/CameraViewUnitTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/components/camera/CameraViewUnitTest.java
@@ -1,0 +1,108 @@
+package org.thoughtcrime.securesms.components.camera;
+import android.content.Context;
+import android.util.Log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CameraView.class ,android.hardware.Camera.class, android.hardware.Camera.CameraInfo.class})
+public class CameraViewUnitTest {
+
+    private final String TAG = CameraView.class.getSimpleName();
+
+    private TextSecurePreferences mockTextSecurePreference;
+    private static CameraView mockCameraView;
+    private Context mockContext;
+
+    @Before
+    public void setUp() {
+
+        mockTextSecurePreference = PowerMockito.mock(TextSecurePreferences.class);
+        mockCameraView = PowerMockito.mock(CameraView.class);
+        mockContext = PowerMockito.mock(Context.class);
+    }
+
+    @Test
+    public void testFlipCamera() {
+
+        PowerMockito.mockStatic(android.hardware.Camera.class);
+        PowerMockito.mockStatic(TextSecurePreferences.class);
+        PowerMockito.mockStatic(CameraView.class);
+
+        int currentId;
+        final int CAMERA_FACING_BACK = 0;
+        final int CAMERA_FACING_FRONT = 1;
+
+        when(android.hardware.Camera.getNumberOfCameras()).thenReturn(2);
+
+        // Set the internal state of 'cameraId' field in the mockCameraView instance
+        // to value 0, which is asserted to be equal to value CAMERA_FACING_BACK
+        Whitebox.setInternalState(mockCameraView, "cameraId", 0);
+        currentId = Whitebox.getInternalState(mockCameraView, "cameraId");
+        assertEquals(currentId, CAMERA_FACING_BACK);
+
+        // The flipCamera method is called with the mockCameraView having the internal
+        // state set for cameraId = 0.
+        mockCameraView.flipCamera();
+
+        // Set the internal state of 'cameraId' field in the mockCameraView instance
+        // to value 1, which is asserted to be equal to value CAMERA_FACING_FRONT
+        Whitebox.setInternalState(mockCameraView, "cameraId", 1);
+        currentId = Whitebox.getInternalState(mockCameraView, "cameraId");
+        assertEquals(currentId, CAMERA_FACING_FRONT);
+
+        // The flipCamera method is called with the mockCameraView having the internal
+        // state set for cameraId = 1.
+        mockCameraView.flipCamera();
+
+        try{
+            // doAnswer will execute when flipCamera is called by mockCameraView
+            PowerMockito.doAnswer((Answer) invocation -> {
+
+                // Grab the current value of 'cameraId'
+                int currentCameraId = Whitebox.getInternalState(mockCameraView, "cameraId");
+                int newCurrentCameraId;
+
+                // If the camera is back-facing, the 'currentId' in mockCameraView is changed to 1.
+                if (currentCameraId == CAMERA_FACING_BACK){
+                    Whitebox.setInternalState(mockCameraView, "cameraId", CAMERA_FACING_FRONT);
+                    newCurrentCameraId =  Whitebox.getInternalState(mockCameraView, "cameraId");
+
+                    // The new value is asserted to be equal to value CAMERA_FACING_FRONT.
+                    assertEquals(CAMERA_FACING_FRONT, newCurrentCameraId);
+
+                    // Verifying that the call to setDirectCaptureCameraId() was called by an instance of TextSecurePreference
+                    // within the flipCamera() method.
+                    verify(mockTextSecurePreference).setDirectCaptureCameraId(mockContext, newCurrentCameraId);
+                }
+                // If the camera is front-facing, the 'currentId' in mockCameraView is changed to 0.
+                else if (currentCameraId == CAMERA_FACING_FRONT){
+                    Whitebox.setInternalState(mockCameraView, "cameraId", CAMERA_FACING_BACK);
+                    newCurrentCameraId =  Whitebox.getInternalState(mockCameraView, "cameraId");
+
+                    // The new value is asserted to be equal to value CAMERA_FACING_BACK.
+                    assertEquals(CAMERA_FACING_BACK, newCurrentCameraId);
+
+                    // Verifying that the call to setDirectCaptureCameraId() was called by an instance of TextSecurePreference
+                    // within the flipCamera() method.
+                    verify(mockTextSecurePreference).setDirectCaptureCameraId(mockContext, newCurrentCameraId);
+                }
+                return null;
+            }).when(mockCameraView).flipCamera();
+        }catch(Exception e){
+            Log.d(TAG, e.getMessage());
+        }
+    }
+}

--- a/test/unitTest/java/org/thoughtcrime/securesms/util/DoubleTapGestureDetectorUnitTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/util/DoubleTapGestureDetectorUnitTest.java
@@ -1,0 +1,75 @@
+package org.thoughtcrime.securesms.util;
+
+import android.view.MotionEvent;
+import android.widget.ImageButton;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.thoughtcrime.securesms.components.camera.CameraView;
+import org.thoughtcrime.securesms.components.camera.QuickAttachmentDrawer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({MotionEvent.class, CameraView.class, QuickAttachmentDrawer.class})
+public class DoubleTapGestureDetectorUnitTest {
+
+    private CameraView mockCameraView;
+    private QuickAttachmentDrawer mockQuickAttachmentDrawer;
+    private DoubleTapGestureDetector testDoubleTapper;
+    private MotionEvent motionEvent;
+    private ImageButton mockImageButton;
+
+    @Before
+    public void setUp() {
+
+        mockCameraView = PowerMockito.mock(CameraView.class);
+        mockQuickAttachmentDrawer = PowerMockito.mock(QuickAttachmentDrawer.class);
+        testDoubleTapper = new DoubleTapGestureDetector(mockQuickAttachmentDrawer, mockCameraView);
+        motionEvent = PowerMockito.mock(MotionEvent.class);
+        mockImageButton = PowerMockito.mock(ImageButton.class);
+    }
+
+    @Test
+    public void testOnDoubleTap() {
+
+        PowerMockito.mockStatic(MotionEvent.class);
+
+        // Stubbing values needed within th eonDoubleTap() method.
+        when(MotionEvent.obtain(200, 300, 0, 0, 0, 0)).thenReturn(motionEvent);
+        when(mockCameraView.isRearCamera()).thenReturn(true);
+        when(mockQuickAttachmentDrawer.getSwapCameraButton()).thenReturn(mockImageButton);
+        when(mockQuickAttachmentDrawer.getBackCameraIcon()).thenReturn(mockImageButton);
+        when(mockQuickAttachmentDrawer.getFrontCameraIcon()).thenReturn(mockImageButton);
+
+        // Calling the methods used in the stubs
+        motionEvent = MotionEvent.obtain(200, 300, 0, 0, 0, 0);
+        testDoubleTapper.onDoubleTap(motionEvent);
+
+        // Verifying that the method flipCamera() was called by the CameraView when the onDoubleTap() method is triggered.
+        verify(mockCameraView).flipCamera();
+    }
+
+    @Test
+    public void testOnDoubleTapEvent() {
+
+        PowerMockito.mockStatic(MotionEvent.class);
+
+        // Stubbing values
+        when(MotionEvent.obtain(200, 300, 0, 0, 0, 0)).thenReturn(motionEvent);
+
+        // Calling the methods used in the stubs
+        motionEvent = MotionEvent.obtain(200, 300, 0, 0, 0, 0);
+
+        // Asserting that the event is in fact a double and not a single tap.
+        assertTrue(testDoubleTapper.onDoubleTapEvent(motionEvent));
+        assertFalse(testDoubleTapper.onSingleTapConfirmed(motionEvent));
+    }
+}


### PR DESCRIPTION
Implemented double tap functionality on quick attachment camera in order to flip camera direction. Note that this functionality only works on the quick camera (which is activated by the camera icon in the compose panel). If users choose the camera option in the attachments menu, this will activate the specific phone's native camera and this feature will not be available. 

Introduces an icon in order to demonstrate which side of the camera is currently being viewed (mainly for testing purposes). 

Closes #95 